### PR TITLE
fix manuscript

### DIFF
--- a/JOSS/paper.md
+++ b/JOSS/paper.md
@@ -36,7 +36,7 @@ A key distinguishing feature of `Fortuna.jl` is that it is capable of performing
 
 Consider a simple reliability problem from @Echard:2013 with the limit state function given by
 \begin{equation}
-g(U_1,U_2) = \dfrac{1}{2} (U_1 - 2) ^ 2 - \dfrac{3}{2} (U_2 - 5) ^ 3 - 3,
+g(U_1,U_2) = \frac{1}{2} (U_1 - 2) ^ 2 - \frac{3}{2} (U_2 - 5) ^ 3 - 3,
 \label{EQ:LimitStateFunction}
 \end{equation}
 where $U_1$ and $U_2$ are two independent standard normal random variables. The failure domain defined by this limit state function is shown in \autoref{FIG:FailureDomain}. The reference geometric reliability index $\beta$ and failure probability $P_f$ obtained using the first-order reliability method (FORM) are $3.93$ and $4.21 \times 10 ^ {-5}$, respectively. These results can be easily recreated using `Fortuna.jl`:

--- a/JOSS/paper.md
+++ b/JOSS/paper.md
@@ -50,7 +50,7 @@ U = [randomvariable("Normal", "M", [0, 1]),
 ρ = [1 0; 0 1]
 
 # Define the limit state function:
-g(u::Vector) = 0.5 * (u[1] - 2) ^ 2 - 1.5 * (u[2] - 5) ^ 3 - 3
+g(u::AbstractVector) = 0.5 * (u[1] - 2) ^ 2 - 1.5 * (u[2] - 5) ^ 3 - 3
 
 # Define the reliability problem and solve it using the FORM:
 Problem = ReliabilityProblem(U, ρ, g)


### PR DESCRIPTION
Due to the JOSS submission:

https://github.com/openjournals/joss-reviews/issues/6967

This fix replaces `dfrac` with `frac`