### PR TITLE
Switch to `DifferentiationInterfection.jl`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Damir Akchurin"]
 version = "0.10.1"
 
 [deps]
+DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 FastGaussQuadrature = "442a2c76-b920-505d-bb47-c5924d526838"
@@ -15,9 +16,11 @@ PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
+DifferentiationInterface = "0.6.40"
 Distributions = "0.25"
 DocStringExtensions = "0.9"
 FastGaussQuadrature = "0.5, 1"
@@ -27,6 +30,7 @@ NonlinearSolve = "1, 2, 3, 4"
 PrecompileTools = "1"
 ProgressMeter = "1"
 Reexport = "1"
+ReverseDiff = "1.15.3"
 SpecialFunctions = "2"
 julia = "1.9.0"
 

--- a/docs/src/AdvancedUsage.md
+++ b/docs/src/AdvancedUsage.md
@@ -149,13 +149,13 @@ g(x::Vector) = 1 - CantileverBeam(x)
 Problem = ReliabilityProblem(X, ρˣ, g)
 
 # Perform the reliability analysis using the FORM:
-FORMSolution = solve(Problem, FORM(), diff = :numeric)
+FORMSolution = solve(Problem, FORM(), backend = AutoFiniteDiff())
 println("FORM:")
 println("β: $(FORMSolution.β)")
 println("PoF: $(FORMSolution.PoF)")
 
 # Perform the reliability analysis using the SORM:
-SORMSolution = solve(Problem, SORM(), FORMSolution = FORMSolution, diff = :numeric)
+SORMSolution = solve(Problem, SORM(), FORMSolution = FORMSolution, backend = AutoFiniteDiff())
 println("SORM:")
 println("β: $(SORMSolution.β₂[1]) (Hohenbichler and Rackwitz)")
 println("β: $(SORMSolution.β₂[2]) (Breitung)")
@@ -163,7 +163,7 @@ println("PoF: $(SORMSolution.PoF₂[1]) (Hohenbichler and Rackwitz)")
 println("PoF: $(SORMSolution.PoF₂[2]) (Breitung)")
 ```
 
-Observe that `diff = :numeric` keyword argument was used in `solve()` function. This forces `Fortuna.jl` package to use numerical differentiation to evaluate the gradients and Hessians of the limit state function since the finite element (FE) model of the cantilever beam, defined using `InstantFrame.jl` package, is not automatically differentiable. Note that you would still obtain a solution if you didn't use `diff = :numeric` keyword argument, but each time `Fortuna.jl` package needs to differentiate the limit state function, it would (1) attempt to differentiate it automatically, and after it fails, (2) it would differentiate it numerically, significantly slowing down the reliability analysis.
+Observe that `backend = AutoDiniteDiff()` keyword argument was used in `solve()` function. This forces `Fortuna.jl` package to use numerical differentiation to evaluate the gradients and Hessians of the limit state function since the finite element (FE) model of the cantilever beam, defined using `InstantFrame.jl` package, is not automatically differentiable. Note that you would still obtain a solution if you didn't use `backend = AutoDiniteDiff()` keyword argument, but each time `Fortuna.jl` package needs to differentiate the limit state function, it would (1) attempt to differentiate it automatically, and after it fails, (2) it would differentiate it numerically, significantly slowing down the reliability analysis.
 
 ### Python-Based FE Models: `OpenSeesPy`
 
@@ -301,13 +301,13 @@ g(x::Vector) = 1 - CantileverBeam(x)
 Problem = ReliabilityProblem(X, ρˣ, g)
 
 # Perform the reliability analysis using the FORM:
-FORMSolution = solve(Problem, FORM(), diff = :numeric)
+FORMSolution = solve(Problem, FORM(), backend = AutoFiniteDiff())
 println("FORM:")
 println("β: $(FORMSolution.β)")
 println("PoF: $(FORMSolution.PoF)")
 
 # Perform the reliability analysis using the SORM:
-SORMSolution = solve(Problem, SORM(), FORMSolution = FORMSolution, diff = :numeric)
+SORMSolution = solve(Problem, SORM(), FORMSolution = FORMSolution, backend = AutoFiniteDiff())
 println("SORM:")
 println("β: $(SORMSolution.β₂[1]) (Hohenbichler and Rackwitz)")
 println("β: $(SORMSolution.β₂[2]) (Breitung)")
@@ -561,13 +561,13 @@ ĝ(x::Vector) = 1 - CantileverBeamSurrogate(x)
 Problem = ReliabilityProblem(X, ρˣ, ĝ)
 
 # Perform the reliability analysis using the FORM:
-FORMSolution = solve(Problem, FORM(), diff = :numeric)
+FORMSolution = solve(Problem, FORM(), backend = AutoFiniteDiff())
 println("FORM:")
 println("β: $(FORMSolution.β)")
 println("PoF: $(FORMSolution.PoF)")
 
 # Perform the reliability analysis using the SORM:
-SORMSolution = solve(Problem, SORM(), FORMSolution = FORMSolution, diff = :numeric)
+SORMSolution = solve(Problem, SORM(), FORMSolution = FORMSolution, backend = AutoFiniteDiff())
 println("SORM:")
 println("β: $(SORMSolution.β₂[1]) (Hohenbichler and Rackwitz)")
 println("β: $(SORMSolution.β₂[2]) (Breitung)")

--- a/src/Fortuna.jl
+++ b/src/Fortuna.jl
@@ -5,8 +5,7 @@ module Fortuna
 import Base
 import Distributions
 import FastGaussQuadrature
-import FiniteDiff
-import ForwardDiff
+using DifferentiationInterface, ForwardDiff, ReverseDiff, FiniteDiff
 import LinearAlgebra
 import NonlinearSolve
 import Random

--- a/src/Reliability Problems/SORM.jl
+++ b/src/Reliability Problems/SORM.jl
@@ -78,17 +78,14 @@ end
 solve(Problem::ReliabilityProblem, AnalysisMethod::SORM; 
     FORMSolution::Union{Nothing, HLRFCache, iHLRFCache} = nothing,
     FORMConfig::FORM = FORM(), 
-    diff::Symbol = :automatic)
+    backend = AutoForwardDiff())
 
-Function used to solve reliability problems using Second-Order Reliability Method (SORM). \\
-If `diff` is:
-- `:automatic`, then the function will use automatic differentiation to compute gradients, jacobians, etc.
-- `:numeric`, then the function will use numeric differentiation to compute gradients, jacobians, etc.
+Function used to solve reliability problems using Second-Order Reliability Method (SORM).
 """
 function solve(Problem::ReliabilityProblem, AnalysisMethod::SORM; 
         FORMSolution::Union{Nothing, RFCache, HLRFCache, iHLRFCache} = nothing,
         FORMConfiguration::FORM = FORM(), 
-        diff::Symbol = :automatic)
+        backend = AutoForwardDiff())
     # Extract the analysis method:
     Submethod  = AnalysisMethod.Submethod
 
@@ -96,8 +93,7 @@ function solve(Problem::ReliabilityProblem, AnalysisMethod::SORM;
     isa(FORMConfiguration.Submethod, MCFOSM) && throw(ArgumentError("MCFOSM cannot be used with SORM as it does not provide any information about the design point!"))
 
     # Determine the design point using FORM:
-    
-    FORMSolution = isnothing(FORMSolution) ? solve(Problem, FORMConfiguration, diff = diff) : FORMSolution
+    FORMSolution = isnothing(FORMSolution) ? solve(Problem, FORMConfiguration, backend = backend) : FORMSolution
     u            = FORMSolution.u[:, end]
     ∇G           = FORMSolution.∇G[:, end]
     α            = FORMSolution.α[:, end]
@@ -195,29 +191,21 @@ function solve(Problem::ReliabilityProblem, AnalysisMethod::SORM;
             end
 
             # Negative side:
-            Problem⁻             = NonlinearSolve.NonlinearProblem(F, β₁, -H)
-            Solution⁻            = if diff == :automatic
-                try
-                    NonlinearSolve.solve(Problem⁻, nothing, abstol = 1E-9, reltol = 1E-9)
-                catch
-                    NonlinearSolve.solve(Problem⁻, NonlinearSolve.FastShortcutNonlinearPolyalg(autodiff = NonlinearSolve.AutoFiniteDiff()), abstol = 1E-9, reltol = 1E-9)
-                end
-            elseif diff == :numeric
-                NonlinearSolve.solve(Problem⁻, NonlinearSolve.FastShortcutNonlinearPolyalg(autodiff = NonlinearSolve.AutoFiniteDiff()), abstol = 1E-9, reltol = 1E-9)
+            Problem⁻  = NonlinearSolve.NonlinearProblem(F, β₁, -H)
+            Solution⁻ = try
+                NonlinearSolve.solve(Problem⁻, nothing, abstol = 1E-9, reltol = 1E-9)
+            catch
+                NonlinearSolve.solve(Problem⁻, NonlinearSolve.FastShortcutNonlinearPolyalg(autodiff = AutoFiniteDiff()), abstol = 1E-9, reltol = 1E-9)
             end
             FittingPoints⁻[i, 1] = -H
             FittingPoints⁻[i, 2] = Solution⁻.u
 
             # Positive side:
-            Problem⁺             = NonlinearSolve.NonlinearProblem(F, β₁, +H)
-            Solution⁺            = if diff == :automatic
-                try
-                    NonlinearSolve.solve(Problem⁺, nothing, abstol = 1E-9, reltol = 1E-9)
-                catch
-                    NonlinearSolve.solve(Problem⁺, NonlinearSolve.FastShortcutNonlinearPolyalg(autodiff = NonlinearSolve.AutoFiniteDiff()), abstol = 1E-9, reltol = 1E-9)
-                end
-            elseif diff == :numeric
-                NonlinearSolve.solve(Problem⁺, NonlinearSolve.FastShortcutNonlinearPolyalg(autodiff = NonlinearSolve.AutoFiniteDiff()), abstol = 1E-9, reltol = 1E-9)
+            Problem⁺  = NonlinearSolve.NonlinearProblem(F, β₁, +H)
+            Solution⁺ = try
+                NonlinearSolve.solve(Problem⁺, nothing, abstol = 1E-9, reltol = 1E-9)
+            catch
+                NonlinearSolve.solve(Problem⁻, NonlinearSolve.FastShortcutNonlinearPolyalg(autodiff = AutoFiniteDiff()), abstol = 1E-9, reltol = 1E-9)
             end
             FittingPoints⁺[i, 1] = +H
             FittingPoints⁺[i, 2] = Solution⁺.u

--- a/test/TestSSM.jl
+++ b/test/TestSSM.jl
@@ -22,7 +22,7 @@
         Solution = solve(Problem, SSM())
 
         # Test the results:
-        @test isapprox(Solution.PoF, cdf(Normal(), -βList[i]), rtol = 0.05)
+        @test isapprox(Solution.PoF, cdf(Normal(), -βList[i]), rtol = 0.10)
     end
 end
 
@@ -52,5 +52,5 @@ end
     Solution = solve(Problem, SSM())
 
     # Test the results:
-    @test isapprox(Solution.PoF, 3.53 * 10 ^ (-7), rtol = 5E-2)
+    @test isapprox(Solution.PoF, 3.53 * 10 ^ (-7), rtol = 0.10)
 end


### PR DESCRIPTION
# Description

**Closes #92.**

Gradient of the limit state function in many reliability analysis methods are now properly preallocated and computed in-place using `DifferentiationInterface.jl` package. The package now support `ForwardDiff.jl`, `ReverseDiff.jl`, and `FiniteDiff.jl` backends by default. If a user want another backend, they will have to load that separately.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist

- [ ] Added an entry into NEWS.md.
- [x] Added or changed relevant sections in the documentation.
- [x] Added unit tests.